### PR TITLE
Force bintray version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,14 @@ shadowJar {
 jar.deleteAllActions()
 jar.dependsOn shadowJar
 
+bintray {
+    pkg {
+        version {
+            name = '0.4.19.1'
+        }
+    }
+}
+
 afterEvaluate {
     publishing {
         publications {


### PR DESCRIPTION
### Context

The version is mismatched, despite the maven metadata being correct. Force the bintray version to `0.4.19.1` so it can be reached as a dependency.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
